### PR TITLE
Change NewUnitLoadBufferLoc definition to avoid conflicts

### DIFF
--- a/EngineHacks/Config.event
+++ b/EngineHacks/Config.event
@@ -204,7 +204,7 @@
 // The location it is repointed to is also defined here. The default location is
 // the area used for debug printing.
 #define REPOINT_UNIT_LOAD_BUFFER
-#define NewUnitLoadBufferLoc 0x2026E30
+#define NewUnitLoadBufferLoc 0x2026F30
 
 
 // =================================


### PR DESCRIPTION
Holy blood stuff takes up occupies `0x2026E30` in RAM. `0x2026F30` works fine from basic testing.